### PR TITLE
feat: add highlight clipping

### DIFF
--- a/svsp-ai/.gitignore
+++ b/svsp-ai/.gitignore
@@ -1,5 +1,7 @@
-# Sample videos
+# Sample videos, caches, outputs
 examples/
+cache
+output
 
 # Python cache
 __pycache__/

--- a/svsp-ai/main.py
+++ b/svsp-ai/main.py
@@ -1,12 +1,24 @@
 from utils.video_to_summarization import video_to_summarization
 from utils.logging_initialization import initialize_logging
-
+from utils.video_processor import cut_video_by_timestamps
+import os
 
 def main():
     initialize_logging()
-    VIDEO_PATH = "{target video path}"
-    video_to_summarization(VIDEO_PATH)
+    VIDEO_PATH = r"/home/gianella/datasets/test_videos/How to Knit the Box Stitch.webm"
+    
+    # Define output path for the summarized video
+    output_dir = "./output"
+    os.makedirs(output_dir, exist_ok=True)
+    base_filename = os.path.splitext(os.path.basename(VIDEO_PATH))[0]
+    SUMMARIZED_VIDEO_PATH = os.path.join(output_dir, f"{base_filename}_summary.mp4")
 
+    summary_text, timestamps = video_to_summarization(VIDEO_PATH)
+
+    cut_video_by_timestamps(VIDEO_PATH, timestamps, SUMMARIZED_VIDEO_PATH)
+
+    print("--- Video Summary ---")
+    print(summary_text)
 
 if __name__ == '__main__':
     main()

--- a/svsp-ai/main.py
+++ b/svsp-ai/main.py
@@ -2,23 +2,24 @@ from utils.video_to_summarization import video_to_summarization
 from utils.logging_initialization import initialize_logging
 from utils.video_processor import cut_video_by_timestamps
 import os
+import argparse
+
 
 def main():
     initialize_logging()
-    VIDEO_PATH = r"/home/gianella/datasets/test_videos/How to Knit the Box Stitch.webm"
-    
-    # Define output path for the summarized video
-    output_dir = "./output"
-    os.makedirs(output_dir, exist_ok=True)
+    parser = argparse.ArgumentParser(description="Video summarization script")
+    parser.add_argument("-f", "--file", type=str, required=True, help="Path to the input video file")
+    args = parser.parse_args()
+
+    VIDEO_PATH = args.file
+    OUTPUT_PATH = "./output"
+    os.makedirs(OUTPUT_PATH, exist_ok=True)
     base_filename = os.path.splitext(os.path.basename(VIDEO_PATH))[0]
-    SUMMARIZED_VIDEO_PATH = os.path.join(output_dir, f"{base_filename}_summary.mp4")
+    SUMMARIZED_VIDEO_PATH = os.path.join(OUTPUT_PATH, f"{base_filename}_summary.mp4")
 
     summary_text, timestamps = video_to_summarization(VIDEO_PATH)
-
     cut_video_by_timestamps(VIDEO_PATH, timestamps, SUMMARIZED_VIDEO_PATH)
 
-    print("--- Video Summary ---")
-    print(summary_text)
 
 if __name__ == '__main__':
     main()

--- a/svsp-ai/utils/video_processor.py
+++ b/svsp-ai/utils/video_processor.py
@@ -1,0 +1,68 @@
+# Takes a video file and a list of timestamps, 
+# cuts the video into segments based on the timestamps,
+
+import os
+import logging
+from typing import List, Tuple
+import ffmpeg
+
+
+def cut_video_by_timestamps(video_path: str, timestamps: List[Tuple[float, float]], output_path: str):
+    """
+    Cuts a video into segments based on timestamps and concatenates them.
+
+    Args:
+        video_path (str): Path to the input video file.
+        timestamps (list): A list of (start_time, end_time) tuples in seconds.
+        output_path (str): Path to save the final concatenated video.
+    """
+    
+    # timestamps is a list of (start, end) tuples
+    if not timestamps:
+        logging.warning("No timestamps provided for video cutting. Skipping.")
+        return
+
+    if not os.path.exists(video_path):
+        logging.error(f"Input video not found at: {video_path}")
+        raise FileNotFoundError(f"Input video not found at: {video_path}")
+
+    try:
+        input_stream = ffmpeg.input(video_path)
+        video_segments = []
+        audio_segments = []
+
+        # iterates  through each (start, end) tuple in timestamps
+        for i, (start, end) in enumerate(timestamps):
+            logging.debug(f"Preparing segment {i}: from {start}s to {end}s")
+            # Using trim and atrim filters. setpts/asetpts are crucial for correct concatenation.
+
+            # trims both the video and audio streams to the specified start and end times
+            
+            # PTS-STARTPTS resets the timestamps to start from zero for each segment
+            # without this when concatenating, there would be large gaps of black video/audio
+            # corresponding to the parts of the original video that were cut out
+
+            video_segments.append(
+                input_stream.video.trim(start=start, end=end).setpts('PTS-STARTPTS')
+            )
+            audio_segments.append(
+                input_stream.audio.filter('atrim', start=start, end=end).filter('asetpts', 'PTS-STARTPTS')
+            )
+
+        # Concatenate all video and audio segments
+        concatenated_video = ffmpeg.concat(*video_segments, v=1, a=0)
+        concatenated_audio = ffmpeg.concat(*audio_segments, v=0, a=1)
+
+        # Combine the concatenated video and audio streams into the final output file
+        (
+            ffmpeg
+            .output(concatenated_video, concatenated_audio, output_path, vcodec='libx264', acodec='aac')
+            .overwrite_output()
+            .run(capture_stdout=True, capture_stderr=True)
+        )
+        logging.info(f"Successfully created summarized video at: {output_path}")
+
+    except ffmpeg.Error as e:
+        logging.error("ffmpeg error occurred:")
+        logging.error(e.stderr.decode())
+        raise

--- a/svsp-ai/utils/video_processor.py
+++ b/svsp-ai/utils/video_processor.py
@@ -47,7 +47,10 @@ def cut_video_by_timestamps(video_path: str, timestamps: List[Tuple[float, float
             )
             audio_segments.append(
                 input_stream.audio.filter('atrim', start=start, end=end).filter('asetpts', 'PTS-STARTPTS')
-            )
+            ) 
+            # filter applies atrim and asetpts to the audio stream
+            # atrim trims the audio to the specified start and end times
+            # asetpts resets the audio timestamps to start from zero for each segment
 
         # Concatenate all video and audio segments
         concatenated_video = ffmpeg.concat(*video_segments, v=1, a=0)

--- a/svsp-ai/utils/video_to_summarization.py
+++ b/svsp-ai/utils/video_to_summarization.py
@@ -1,24 +1,51 @@
 from .video_to_audio import convert_video_to_audio
 from .audio_to_text import transcribe_audio
 from .llm_client import call_gemini
-import logging, shutil, os
+import logging, shutil, os, json
+from typing import List, Tuple
 
 
 def video_to_summarization(VIDEO_PATH):
     CACHE_PATH = "./cache"
 
-    audio_file = convert_video_to_audio(VIDEO_PATH, CACHE_PATH)
+    try:
+        audio_file = convert_video_to_audio(VIDEO_PATH, CACHE_PATH)
+        if not audio_file:
+            raise Exception("Audio conversion failed.")
 
-    audio_path = os.path.join(CACHE_PATH, audio_file)
-    text = transcribe_audio(audio_path)
-    logging.debug(f"Transcription result => {text}")
+        audio_path = os.path.join(CACHE_PATH, audio_file)
+        transcribed_segments = transcribe_audio(audio_path)
+        if not isinstance(transcribed_segments, list):
+             raise Exception(f"Transcription failed: {transcribed_segments}")
+        logging.debug(f"Transcription result => {transcribed_segments}")
 
-    prompt = f"This is sentence with corresponding timestamp. {str(text)} Please pick important sentence and remove the rest. Try to make total length maximum up to 1 minute. Right your answer in a same format"
-    summarization = call_gemini("gemini-2.5-flash", prompt)
-    logging.debug(f"summarization result => {summarization['text']}")
+        prompt = f"""
+        You are a video summarization assistant.
+        Given a list of transcribed segments with timestamps, select the most important segments to create a summary of up to 1 minute.
+        Respond with a JSON object containing a single key "timestamps", which is a list of [start, end] arrays for the selected segments.
 
-    if os.path.exists(CACHE_PATH):
-        shutil.rmtree(CACHE_PATH)
-        logging.debug(f"Removed cache folder: {CACHE_PATH}")
+        Example Input:
+        [('Hello world.', (0.5, 1.5)), ('This is a test.', (2.0, 3.0)), ('Another important segment.', (10.0, 12.5))]
 
-    return summarization['text']
+        Example Output:
+        {{ "timestamps": [ [0.5, 1.5], [10.0, 12.5] ] }}
+
+        Transcribed Segments:
+        {str(transcribed_segments)}
+        """
+        summarization_result = call_gemini("gemini-2.5-flash", prompt, as_json=True)
+        summary_json = summarization_result.get('json')
+        logging.debug(f"Summarization result => {summary_json}")
+
+        if not summary_json or "timestamps" not in summary_json:
+            raise Exception(f"Failed to get valid timestamps from LLM. Response: {summary_json}")
+
+        timestamps = summary_json["timestamps"]
+        logging.info(f"Parsed timestamps for cutting: {timestamps}")
+
+        # The raw text response is no longer the primary source of data, but can be returned for logging/display
+        return summarization_result['text'], timestamps
+
+    finally:
+        if os.path.exists(CACHE_PATH):
+            logging.debug(f"Removed cache folder: {CACHE_PATH}")

--- a/svsp-ai/utils/video_to_summarization.py
+++ b/svsp-ai/utils/video_to_summarization.py
@@ -43,6 +43,10 @@ def video_to_summarization(VIDEO_PATH):
         timestamps = summary_json["timestamps"]
         logging.info(f"Parsed timestamps for cutting: {timestamps}")
 
+        if os.path.exists(CACHE_PATH):
+            shutil.rmtree(CACHE_PATH)
+            logging.debug(f"Removed cache folder: {CACHE_PATH}")
+
         # The raw text response is no longer the primary source of data, but can be returned for logging/display
         return summarization_result['text'], timestamps
 


### PR DESCRIPTION
# Add clip cutting

## Description

Added `video_processor.py`, which uses `ffmpeg` to cut the video in segments based on timestamps. It requires `ffmpeg-python`. 

```bash
pip install ffmpeg-python
```

`video_processor.py` works as follows:
- It expects the video path, timestamps (tuple) and an output path.
- It loads the input stream.
- It intializes a list of video segments and audio segments. 
- It iterates through each tuple timestamp and trims the video and audio streams to the specified start and end times.
- Each cut of video and audio are added to the video and audio lists respectively.
- The contents of each list is concatenated.
- The concatenated video and audio streams are combined into the final output file. 

### Other Changes

- `video_to_summarization.py`
	- The prompt was refined to be more explicit. It now includes example inputs and outputs.
	- The prompt asks to expect a `json` object and processes it as such. 

- `llm_client.py`
	- Note that as of now, testing has been mainly done using Gemini 2.5. Flash and not GPT due to lack of access to the paid credits.
	- Configured the API call to tell the Gemini model to respond with a valid JSON object. 

## Known issues

- Sometimes the cut is not done in an optimal section; the summary ends up being to uncontextualized or hard to understand
	- I think that to address this, we could generate multiple summaries instead of just one, and prompt the user to choose.